### PR TITLE
feat: add a basic support to convert `ProtoMessage` to `string`

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,9 +1,10 @@
-import { parseRootObjectToProtoMessage } from '.'
+import { parseRootObjectToProtoMessage, convertProtoMessageToString } from '.'
 import {
   ProtoMessage,
   ProtoField,
   ProtoType,
   ProtoPrimitive,
+  ProtoPrimitiveMap,
 } from './models/models_pb'
 
 describe('index', () => {
@@ -11,26 +12,90 @@ describe('index', () => {
     expect.hasAssertions()
 
     const obj = {
-      keyName: 'mo kweon',
+      fieldName: 'mo kweon',
     }
 
-    // The expected proto
-    //
-    // message Root {
-    //   string keyName = 1;
-    // }
-    const expected = new ProtoMessage()
-    expected.setName('root')
+    expect(parseRootObjectToProtoMessage(obj)).toStrictEqual(
+      getSimpleProtoMessage(),
+    )
+  })
 
-    const protoField = new ProtoField()
-    protoField.setName('key_name')
-    protoField.setTag(1)
+  it('should convert the ProtoMessage to string', () => {
+    expect(convertProtoMessageToString(getSimpleProtoMessage())).toStrictEqual(`
+message Root {
+  string field_name = 1;
+}`)
+  })
 
-    const protoType = new ProtoType()
-    protoType.setProtoTypePrimitive(ProtoPrimitive.PROTO_PRIMITIVE_STRING)
-    protoField.setType(protoType)
-    expected.addFields(protoField)
+  it('should convert multiple primitive fields to string', () => {
+    const protoMessage = getSimpleProtoMessage()
+    protoMessage.addFields(
+      getPrimitiveProtoField(
+        ProtoPrimitive.PROTO_PRIMITIVE_BOOL,
+        'bool_name',
+        /*fieldTag=*/ 2,
+      ),
+    )
+    protoMessage.addFields(
+      getPrimitiveProtoField(
+        ProtoPrimitive.PROTO_PRIMITIVE_INT64,
+        'int64_name',
+        /*fieldTag=*/ 3,
+      ),
+    )
+    protoMessage.addFields(
+      getPrimitiveProtoField(
+        ProtoPrimitive.PROTO_PRIMITIVE_DOUBLE,
+        'double_name',
+        /*fieldTag=*/ 4,
+      ),
+    )
 
-    expect(parseRootObjectToProtoMessage(obj)).toStrictEqual(expected)
+    expect(convertProtoMessageToString(protoMessage)).toStrictEqual(`
+message Root {
+  string field_name = 1;
+  bool bool_name = 2;
+  int64 int64_name = 3;
+  double double_name = 4;
+}`)
   })
 })
+
+/**
+ * Returns ProtoMessage representing the following Proto definition.
+ *
+ * message Root {
+ *   string field_name = 1;
+ * }
+ */
+function getSimpleProtoMessage(): ProtoMessage {
+  const expected = new ProtoMessage()
+  expected.setName('Root')
+
+  expected.addFields(
+    getPrimitiveProtoField(
+      ProtoPrimitive.PROTO_PRIMITIVE_STRING,
+      'field_name',
+      /*fieldTag=*/ 1,
+    ),
+  )
+
+  return expected
+}
+
+function getPrimitiveProtoField(
+  primitiveType: ProtoPrimitiveMap[keyof ProtoPrimitiveMap],
+  fieldName: string,
+  fieldTag: number,
+): ProtoField {
+  const protoField = new ProtoField()
+  protoField.setName(fieldName)
+  protoField.setTag(fieldTag)
+
+  const protoType = new ProtoType()
+  protoType.setProtoTypePrimitive(primitiveType)
+
+  protoField.setType(protoType)
+
+  return protoField
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,14 @@
-import { ProtoMessage } from './models/models_pb'
+import {
+  ProtoMessage,
+  ProtoField,
+  ProtoPrimitiveMap,
+  ProtoPrimitive,
+} from './models/models_pb'
 import { parseProtoField } from './parse_proto_field'
 
 export function parseRootObjectToProtoMessage(
   obj: object,
-  name = 'root',
+  name = 'Root',
 ): ProtoMessage {
   const root = new ProtoMessage()
 
@@ -14,4 +19,83 @@ export function parseRootObjectToProtoMessage(
   })
 
   return root
+}
+
+/**
+ * Converts ProtoMessage to Proto definition
+ *
+ * For example, the following is the example output.
+ *
+ * message Root {
+ *   string key_name = 1;
+ * }
+ */
+export function convertProtoMessageToString(
+  protoMessage: ProtoMessage,
+): string {
+  return `
+message ${protoMessage.getName()} {
+${convertProtoFields(protoMessage.getFieldsList(), /*depth=*/ 1)}
+}`
+}
+
+/**
+ * Converts ProtoField[] to string
+ *
+ * @param protoFields ProtoField[]
+ * @param depth The depth of 1 means the fields of the root object. Hence, it
+ * needs to be indented with 2 spaces. For example,
+ *
+ * message Root {
+ *   string key_name = 1; // notice there are 2 spaces in this line.
+ * }
+ *
+ * @returns string
+ */
+function convertProtoFields(protoFields: ProtoField[], depth: number): string {
+  const prefix = '  '.repeat(depth)
+  return protoFields
+    .map(protoField => prefix + convertProtoField(protoField))
+    .join('\n')
+}
+
+/**
+ * Converts a single ProtoField into string
+ *
+ * Currently, it only supports primitive types.
+ *
+ * TODO: Support embedded types.
+ */
+function convertProtoField(protoField: ProtoField): string {
+  if (protoField.getType()?.hasProtoTypePrimitive()) {
+    let prefix = protoField.getRepeated() ? 'repeated ' : ''
+
+    const protoFieldType = getProtoTypePrimitiveName(
+      protoField.getType()!.getProtoTypePrimitive(),
+    )
+
+    return `${prefix}${protoFieldType} ${protoField.getName()} = ${protoField.getTag()};`
+  }
+
+  // protoField.getType()?.hasProtoTypeMessage()
+  throw new TypeError(
+    'ProtoTypeMessage is currently not supported for conversion',
+  )
+}
+
+function getProtoTypePrimitiveName(
+  protoTypePrimitive: ProtoPrimitiveMap[keyof ProtoPrimitiveMap],
+): string {
+  switch (protoTypePrimitive) {
+    case ProtoPrimitive.PROTO_PRIMITIVE_STRING:
+      return 'string'
+    case ProtoPrimitive.PROTO_PRIMITIVE_BOOL:
+      return 'bool'
+    case ProtoPrimitive.PROTO_PRIMITIVE_INT64:
+      return 'int64'
+    case ProtoPrimitive.PROTO_PRIMITIVE_DOUBLE:
+      return 'double'
+    case ProtoPrimitive.PROTO_PRIMITIVE_UNKNOWN:
+      return 'unknown'
+  }
 }


### PR DESCRIPTION
For example, it can convert the simple object to 

```proto
message Root {
  string key_name = 1;
}
```